### PR TITLE
Add Close() method to close USB device

### DIFF
--- a/ft232/ft232.go
+++ b/ft232/ft232.go
@@ -77,6 +77,14 @@ func (d *DMXController) Connect() error {
 	return nil
 }
 
+func (d *DMXController) Close() error {
+	device := d.device
+	if device == nil {
+		return fmt.Errorf("not connected")
+	}
+	return device.Close()
+}
+
 // SetChannel sets a single DMX channel value
 func (d *DMXController) SetChannel(index int16, data byte) error {
 	if index < 1 || index > 512 {

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -25,6 +25,10 @@ func (d *DMXController) Connect() error {
 	return nil
 }
 
+func (d *DMXController) Close() error {
+	return nil
+}
+
 // SetChannel sets a single DMX channel value
 func (d *DMXController) SetChannel(index int16, data byte) error {
 	if index < 1 || index > 512 {

--- a/usbdmx.go
+++ b/usbdmx.go
@@ -11,6 +11,7 @@ import (
 // Controller Generic interface for all USB DMX controllers
 type Controller interface {
 	Connect() (err error)
+	Close() error
 	GetSerial() (info string, err error)
 	GetProduct() (info string, err error)
 	SetChannel(channel int16, value byte) error


### PR DESCRIPTION
gousb's OpenDeviceWithVIDPID method comment states:
`A Device.Close() must be called to release the device if the returned device wasn't nil.`. I have added a corresponding Close() method on DMXController so we can release the device once we're done with it.